### PR TITLE
Don't leak PythonInterface::PythonObjVec instances

### DIFF
--- a/SAGEInterface.cpp
+++ b/SAGEInterface.cpp
@@ -15,25 +15,30 @@ void SAGEInterface::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
 }
 
+bool SAGEInterface::doFinalization(Module &) {
+  ObjVec_.reset();
+  return false;
+}
+
 bool SAGEInterface::runOnModule(Module& M) {
   PI_ = &getAnalysis<PythonInterface>();
 
-  ObjVec_ = PI_->createObjVec(getObjVecInit());
+  ObjVec_.reset(PI_->createObjVec(getObjVecInit()));
   assert(ObjVec_);
 
   return false;
 }
 
 PyObject *SAGEInterface::var(const long Val) {
-  return PI_->call(ObjVec_, FN_EXPR_INIT, {PyLong_FromLong(Val)});
+  return PI_->call(ObjVec_.get(), FN_EXPR_INIT, {PyLong_FromLong(Val)});
 }
 
 PyObject *SAGEInterface::var(const unsigned long Val) {
-  return PI_->call(ObjVec_, FN_EXPR_INIT, {PyLong_FromUnsignedLong(Val)});
+  return PI_->call(ObjVec_.get(), FN_EXPR_INIT, {PyLong_FromUnsignedLong(Val)});
 }
 
 PyObject *SAGEInterface::var(const char *Str) {
-  return PI_->call(ObjVec_, FN_EXPR_INIT, {PyString_FromString(Str)});
+  return PI_->call(ObjVec_.get(), FN_EXPR_INIT, {PyString_FromString(Str)});
 }
 
 std::string SAGEInterface::getName(PyObject *Expr) {
@@ -123,23 +128,23 @@ std::vector<PyObject*> SAGEInterface::args(PyObject *Expr) {
 }
 
 PyObject *SAGEInterface::getNaN() {
-  return PI_->call(ObjVec_, FN_NAN, {});
+  return PI_->call(ObjVec_.get(), FN_NAN, {});
 }
 
 PyObject *SAGEInterface::getPlusInf() {
-  return PI_->call(ObjVec_, FN_PLUS_INF, {});
+  return PI_->call(ObjVec_.get(), FN_PLUS_INF, {});
 }
 
 PyObject *SAGEInterface::getMinusInf() {
-  return PI_->call(ObjVec_, FN_MINUS_INF, {});
+  return PI_->call(ObjVec_.get(), FN_MINUS_INF, {});
 }
 
 PyObject *SAGEInterface::getTrue() {
-  return PI_->call(ObjVec_, FN_TRUE, {});
+  return PI_->call(ObjVec_.get(), FN_TRUE, {});
 }
 
 PyObject *SAGEInterface::getFalse() {
-  return PI_->call(ObjVec_, FN_FALSE, {});
+  return PI_->call(ObjVec_.get(), FN_FALSE, {});
 }
 
 long SAGEInterface::getInteger(PyObject *Expr) {

--- a/SAGEInterface.h
+++ b/SAGEInterface.h
@@ -6,6 +6,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <memory>
 #include <vector>
 
 #undef NAN
@@ -44,6 +45,7 @@ public:
   }
 
   virtual void getAnalysisUsage(AnalysisUsage &AU) const;
+  virtual bool doFinalization(Module&);
   virtual bool runOnModule(Module&);
 
   PyObject *var(const long Val);
@@ -114,7 +116,7 @@ public:
 
 private:
   PythonInterface *PI_;
-  PythonInterface::PythonObjVec *ObjVec_;
+  std::unique_ptr<PythonInterface::PythonObjVec> ObjVec_;
 };
 
 #endif


### PR DESCRIPTION
In particular, the instance stored in `SAGEInterface::ObjVec_` is allocated when `SAGEInterface::runOnModule` calls `PythonInterface::createObjVec`, but was never being freed.  Now we manage that resource by storing it in a `std::uniqe_ptr` and explicitly resetting it when finalizing the `SAGEInterface` module pass.

Eventually I will ask Henrique to pick up this fix as well. However, I want him to resolve to a few older pull requests first before I start stacking more new requests atop old ones.

I also have some changes to merge from `valgrind` branches in the `llvm-sage` and `CArrayIntrospection` repositories. However, because of how git branches work, it will be cleanest to start with the lower-level submodules first, then work our way up the module hierarchy. So we’re starting here at the bottom.
