### PR TITLE
Be robust if qepcad does not understand timeout

### DIFF
--- a/Runtime/llvmsage/cad.py
+++ b/Runtime/llvmsage/cad.py
@@ -6,8 +6,11 @@ from pexpect import ExceptionPexpect
 
 def run_qepcad(formula):
   try:
-    # Time out QEPCAD after 2 seconds.
-    return qepcad(formula, timeout=2)
+    try:
+      # Time out QEPCAD after 2 seconds.
+      return qepcad(formula, timeout=2)
+    except TypeError:
+      return qepcad(formula)
   except ExceptionPexpect:
     return 'UNKNOWN'
 


### PR DESCRIPTION
The intent of the existing code is to impose a two-second timeout on qepcad calls.  That seems to work fine in the qepcad interface that ships with sage 6.8.  However, Fedora 23 distributes sage 6.5, and that earlier version does not expect a `timeout=...` keyword parameter.  So this call fails with a `TypeError` exception.

In the revised code, we recognize when this has happened and fall back on creating a qepcad interface object with no timeout at all.  I claim that this is better than failing outright if actual timeout violations are rare.  If they turn out to be common, then we will need to fall back on some other mechanism for detecting them.  We could also decide that sage 6.5 is unacceptably old, but that would impose a large burden of always building our own sage for Fedora.

Incidentally, if we wanted to probe for timeout support before actually calling `qepcad(...)`, we could do it as follows:

``` python
import inspect
if 'timeout' in inspect.getargspec(sage.interfaces.qepcad.Qepcad.__init__).args:
    return qepcad(formula, timeout=2)
else:
    return qepcad(formula)
```

In my opinion this is overkill, though.  Instead, we just try the call with the timeout parameter included, and if that fails with a `TypeError`, then we try it again without the timeout and hope for the best.
